### PR TITLE
Log output revealed sensitive information

### DIFF
--- a/keepass2AndroidPluginSDK/src/main/java/keepass2android/pluginsdk/PluginActionBroadcastReceiver.java
+++ b/keepass2AndroidPluginSDK/src/main/java/keepass2android/pluginsdk/PluginActionBroadcastReceiver.java
@@ -54,7 +54,7 @@ public abstract class PluginActionBroadcastReceiver extends BroadcastReceiver {
 				for(Iterator<String> iter = json.keys();iter.hasNext();) {
 				    String key = iter.next();
 				    String value = json.get(key).toString();
-				    Log.d("KP2APluginSDK", "received " + key+"/"+value);
+				    Log.d("KP2APluginSDK", "received " + key);
 				    res.put(key, value);
 				}
 				


### PR DESCRIPTION
This change stops the values received from K2A from being written to the system-wide log. These values include title, username and password (all in plaintext) for a selected entry.